### PR TITLE
Add attention hints model, dataset, and training script

### DIFF
--- a/src/data_preprocessing/dataset_with_hints.py
+++ b/src/data_preprocessing/dataset_with_hints.py
@@ -1,0 +1,40 @@
+import torch
+from torch.utils.data import Dataset
+
+class MathTextWithAttentionHints(Dataset):
+    def __init__(self, texts, labels, tokenizer, important_words_dict, label2str):
+        self.texts = texts
+        self.labels = labels
+        self.tokenizer = tokenizer
+        self.important_words_dict = important_words_dict
+        self.label2str = label2str
+
+    def __getitem__(self, idx):
+        text = self.texts[idx]
+        label = self.labels[idx]
+        encoding = self.tokenizer(text, padding='max_length', truncation=True, max_length=128, return_tensors='pt')
+        input_ids = encoding['input_ids'].squeeze()
+        attention_mask = encoding['attention_mask'].squeeze()
+        tokens = self.tokenizer.convert_ids_to_tokens(input_ids)
+
+        important = self.important_words_dict[self.label2str[label]]
+        hint_mask = torch.tensor([1 if any(w in t.lower() for w in important) else 0 for t in tokens])
+
+        return {
+            'input_ids': input_ids,
+            'attention_mask': attention_mask,
+            'hint_mask': hint_mask,
+            'labels': torch.tensor(label)
+        }
+
+    def __len__(self):
+        return len(self.texts)
+
+class DataCollatorWithHintMask:
+    def __call__(self, features):
+        return {
+            'input_ids': torch.stack([f['input_ids'] for f in features]),
+            'attention_mask': torch.stack([f['attention_mask'] for f in features]),
+            'hint_mask': torch.stack([f['hint_mask'] for f in features]),
+            'labels': torch.tensor([f['labels'] for f in features])
+        }

--- a/src/models/bert_with_attention_hints.py
+++ b/src/models/bert_with_attention_hints.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from transformers import BertModel, PreTrainedModel, BertConfig
+
+class BertWithAttentionHints(PreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.bert = BertModel(config)
+        self.attn_weights = nn.Linear(config.hidden_size, 1)
+        self.classifier = nn.Linear(config.hidden_size, config.num_labels)
+        self.init_weights()
+
+    def forward(self, input_ids, attention_mask=None, hint_mask=None, labels=None):
+        outputs = self.bert(input_ids=input_ids, attention_mask=attention_mask, return_dict=True)
+        token_embeddings = outputs.last_hidden_state  # [B, T, H]
+
+        # Compute attention weights
+        raw_scores = self.attn_weights(token_embeddings).squeeze(-1)  # [B, T]
+
+        # Mask out non-hint tokens
+        if hint_mask is not None:
+            raw_scores = raw_scores.masked_fill(hint_mask == 0, float('-inf'))
+
+        attention_weights = torch.softmax(raw_scores, dim=1)  # [B, T]
+        attended = torch.sum(token_embeddings * attention_weights.unsqueeze(-1), dim=1)  # [B, H]
+
+        logits = self.classifier(attended)
+
+        loss = None
+        if labels is not None:
+            loss = nn.CrossEntropyLoss()(logits, labels)
+
+        return {'loss': loss, 'logits': logits, 'attention': attention_weights}

--- a/src/train_with_hints.py
+++ b/src/train_with_hints.py
@@ -1,0 +1,47 @@
+import torch
+from transformers import BertConfig, Trainer, TrainingArguments, BertTokenizer, IntervalStrategy
+from src.models.bert_with_attention_hints import BertWithAttentionHints
+from src.data_preprocessing.dataset_with_hints import MathTextWithAttentionHints, DataCollatorWithHintMask
+
+# Example data and configuration
+texts = ["Example text 1", "Example text 2"]
+labels = [0, 1]
+important_words_dict = {"label_0": ["example", "text"], "label_1": ["another", "sample"]}
+label2str = {0: "label_0", 1: "label_1"}
+
+# Initialize tokenizer and dataset
+tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+dataset = MathTextWithAttentionHints(texts, labels, tokenizer, important_words_dict, label2str)
+
+# Split dataset into train and validation
+train_dataset = dataset  # Replace with actual split logic
+val_dataset = dataset  # Replace with actual split logic
+
+# Initialize model configuration and model
+config = BertConfig.from_pretrained("bert-base-uncased", num_labels=2)
+model = BertWithAttentionHints(config)
+
+# Define training arguments
+training_args = TrainingArguments(
+    output_dir="./results",
+    learning_rate=2e-5,
+    per_device_train_batch_size=8,
+    per_device_eval_batch_size=8,
+    num_train_epochs=3,
+    weight_decay=0.01,
+    logging_dir="./logs",
+    logging_steps=10,
+)
+
+# Initialize Trainer
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=train_dataset,
+    eval_dataset=val_dataset,
+    data_collator=DataCollatorWithHintMask(),
+    tokenizer=tokenizer,
+)
+
+# Train the model
+trainer.train()


### PR DESCRIPTION
Fixes #12:
This pull request introduces the following key changes:

-Model Implementation: Added BertWithAttentionHints in [bert_with_attention_hints.py](https://laughing-space-carnival-xqx4x6qxwgv26r7j.github.dev/), which incorporates attention hints for classification tasks.
-Dataset and Data Collator: Implemented MathTextWithAttentionHints and DataCollatorWithHintMask in [dataset_with_hints.py](https://laughing-space-carnival-xqx4x6qxwgv26r7j.github.dev/) to handle hint masks during data preparation.
-Training Script: Added [train_with_hints.py](https://laughing-space-carnival-xqx4x6qxwgv26r7j.github.dev/) to train the model using the dataset and attention hints.
-Dependencies: Installed required libraries, including transformers and accelerate, to support the new functionality.